### PR TITLE
Prepare for usage as package

### DIFF
--- a/grobid_client.py
+++ b/grobid_client.py
@@ -5,7 +5,7 @@ import json
 import argparse
 import time
 import concurrent.futures
-from client import ApiClient
+from grobid_client_python.client import ApiClient
 import ntpath
 import requests
 


### PR DESCRIPTION
Like described in #14, in its current state, the repository cannot be imported due to dashes here and there.
In addition to the small changes here, the repository name would need to be changed to contain underscores instead of dashes.

Since its easy to miss in the github view, this PR:
- [x] renames grobid-client.py to grobid_client.py
- [x] changes the import in grobid_client.py to include the package name
- [x] adds an empty init file
- [x] Renames the reposity to an underscore version (I cannot propose this)

EDIT: This seems to be related to #4, which would probably work after this PR.