### PR TITLE
Code formatting with "black", and make process_pdf() a file-independent function

### DIFF
--- a/client.py
+++ b/client.py
@@ -10,24 +10,19 @@ except ImportError:
 
 
 class ApiClient(object):
-    """ Client to interact with a generic Rest API.
+    """Client to interact with a generic Rest API.
 
     Subclasses should implement functionality accordingly with the provided
     service methods, i.e. ``get``, ``post``, ``put`` and ``delete``.
     """
 
-    accept_type = 'application/xml'
+    accept_type = "application/xml"
     api_base = None
 
     def __init__(
-            self,
-            base_url,
-            username=None,
-            api_key=None,
-            status_endpoint=None,
-            timeout=60
+        self, base_url, username=None, api_key=None, status_endpoint=None, timeout=60
     ):
-        """ Initialise client.
+        """Initialise client.
 
         Args:
             base_url (str): The base URL to the service being used.
@@ -43,7 +38,7 @@ class ApiClient(object):
 
     @staticmethod
     def encode(request, data):
-        """ Add request content data to request body, set Content-type header.
+        """Add request content data to request body, set Content-type header.
 
         Should be overridden by subclasses if not using JSON encoding.
 
@@ -57,14 +52,14 @@ class ApiClient(object):
         if data is None:
             return request
 
-        request.add_header('Content-Type', 'application/json')
+        request.add_header("Content-Type", "application/json")
         request.data = json.dumps(data)
 
         return request
 
     @staticmethod
     def decode(response):
-        """ Decode the returned data in the response.
+        """Decode the returned data in the response.
 
         Should be overridden by subclasses if something else than JSON is
         expected.
@@ -81,7 +76,7 @@ class ApiClient(object):
             return e.message
 
     def get_credentials(self):
-        """ Returns parameters to be added to authenticate the request.
+        """Returns parameters to be added to authenticate the request.
 
         This lives on its own to make it easier to re-implement it if needed.
 
@@ -91,16 +86,16 @@ class ApiClient(object):
         return {"username": self.username, "api_key": self.api_key}
 
     def call_api(
-            self,
-            method,
-            url,
-            headers=None,
-            params=None,
-            data=None,
-            files=None,
-            timeout=None,
+        self,
+        method,
+        url,
+        headers=None,
+        params=None,
+        data=None,
+        files=None,
+        timeout=None,
     ):
-        """ Call API.
+        """Call API.
 
         This returns object containing data, with error details if applicable.
 
@@ -117,11 +112,11 @@ class ApiClient(object):
             ResultParser or ErrorParser.
         """
         headers = deepcopy(headers) or {}
-        headers['Accept'] = self.accept_type
+        headers["Accept"] = self.accept_type
         params = deepcopy(params) or {}
         data = data or {}
         files = files or {}
-        #if self.username is not None and self.api_key is not None:
+        # if self.username is not None and self.api_key is not None:
         #    params.update(self.get_credentials())
         r = requests.request(
             method,
@@ -136,7 +131,7 @@ class ApiClient(object):
         return r, r.status_code
 
     def get(self, url, params=None, **kwargs):
-        """ Call the API with a GET request.
+        """Call the API with a GET request.
 
         Args:
             url (str): Resource location relative to the base URL.
@@ -145,15 +140,10 @@ class ApiClient(object):
         Returns:
             ResultParser or ErrorParser.
         """
-        return self.call_api(
-            "GET",
-            url,
-            params=params,
-            **kwargs
-        )
+        return self.call_api("GET", url, params=params, **kwargs)
 
     def delete(self, url, params=None, **kwargs):
-        """ Call the API with a DELETE request.
+        """Call the API with a DELETE request.
 
         Args:
             url (str): Resource location relative to the base URL.
@@ -162,15 +152,10 @@ class ApiClient(object):
         Returns:
             ResultParser or ErrorParser.
         """
-        return self.call_api(
-            "DELETE",
-            url,
-            params=params,
-            **kwargs
-        )
+        return self.call_api("DELETE", url, params=params, **kwargs)
 
     def put(self, url, params=None, data=None, files=None, **kwargs):
-        """ Call the API with a PUT request.
+        """Call the API with a PUT request.
 
         Args:
             url (str): Resource location relative to the base URL.
@@ -182,16 +167,11 @@ class ApiClient(object):
             An instance of ResultParser or ErrorParser.
         """
         return self.call_api(
-            "PUT",
-            url,
-            params=params,
-            data=data,
-            files=files,
-            **kwargs
+            "PUT", url, params=params, data=data, files=files, **kwargs
         )
 
     def post(self, url, params=None, data=None, files=None, **kwargs):
-        """ Call the API with a POST request.
+        """Call the API with a POST request.
 
         Args:
             url (str): Resource location relative to the base URL.
@@ -203,23 +183,15 @@ class ApiClient(object):
             An instance of ResultParser or ErrorParser.
         """
         return self.call_api(
-            method="POST",
-            url=url,
-            params=params,
-            data=data,
-            files=files,
-            **kwargs
+            method="POST", url=url, params=params, data=data, files=files, **kwargs
         )
 
     def service_status(self, **kwargs):
-        """ Call the API to get the status of the service.
+        """Call the API to get the status of the service.
 
         Returns:
             An instance of ResultParser or ErrorParser.
         """
         return self.call_api(
-            'GET',
-            self.status_endpoint,
-            params={'format': 'json'},
-            **kwargs
+            "GET", self.status_endpoint, params={"format": "json"}, **kwargs
         )

--- a/grobid_client.py
+++ b/grobid_client.py
@@ -9,7 +9,7 @@ import ntpath
 import requests
 import pathlib
 
-'''
+"""
 This version uses the standard ProcessPoolExecutor for parallelizing the concurrent calls to the GROBID services. 
 Given the limits of ThreadPoolExecutor (the legendary GIL, input stored in memory, blocking Executor.map until 
 the whole input is acquired), ProcessPoolExecutor works with batches of PDF of a size indicated in the config.json 
@@ -17,184 +17,333 @@ file (default is 1000 entries). We are moving from first batch to the second one
 processed - which means it is slightly sub-optimal, but should scale better. Working without batch would mean 
 acquiring a list of millions of files in directories and would require something scalable too (e.g. done in a separate 
 thread), which is not implemented for the moment and possibly not implementable in Python as long it uses the GIL.
-'''
-class grobid_client(ApiClient):
+"""
 
-    def __init__(self, config_path='./config.json'):
+
+class grobid_client(ApiClient):
+    def __init__(self, config_path="./config.json"):
         self.config = None
         self._load_config(config_path)
 
-    def _load_config(self, path='./config.json'):
+    def _load_config(self, path="./config.json"):
         """
-        Load the json configuration 
+        Load the json configuration
         """
         config_json = open(path).read()
         self.config = json.loads(config_json)
 
         # test if the server is up and running...
-        the_url = 'http://'+self.config['grobid_server']
-        if len(self.config['grobid_port'])>0:
-            the_url += ":"+self.config['grobid_port']
+        the_url = "http://" + self.config["grobid_server"]
+        if len(self.config["grobid_port"]) > 0:
+            the_url += ":" + self.config["grobid_port"]
         the_url += "/api/isalive"
         try:
             r = requests.get(the_url)
         except:
-            print('GROBID server does not appear up and running, the connection to the server failed')
+            print(
+                "GROBID server does not appear up and running, the connection to the server failed"
+            )
             exit(1)
 
         status = r.status_code
 
         if status != 200:
-            print('GROBID server does not appear up and running ' + str(status))
+            print("GROBID server does not appear up and running " + str(status))
         else:
             print("GROBID server is up and running")
 
-    def process(self, service, input_path, 
-            output=None, 
-            n=10, 
-            generateIDs=False, 
-            consolidate_header=True, 
-            consolidate_citations=False, 
-            include_raw_citations=False, 
-            include_raw_affiliations=False, 
-            teiCoordinates=False,
-            force=True,
-            verbose=False):
-        batch_size_pdf = self.config['batch_size']
+    def process(
+        self,
+        service,
+        input_path,
+        output=None,
+        n=10,
+        generateIDs=False,
+        consolidate_header=True,
+        consolidate_citations=False,
+        include_raw_citations=False,
+        include_raw_affiliations=False,
+        teiCoordinates=False,
+        force=True,
+        verbose=False,
+    ):
+        batch_size_pdf = self.config["batch_size"]
         pdf_files = []
 
         for (dirpath, dirnames, filenames) in os.walk(input_path):
             for filename in filenames:
-                if filename.endswith('.pdf') or filename.endswith('.PDF'): 
+                if filename.endswith(".pdf") or filename.endswith(".PDF"):
                     if verbose:
-                       try:
-                          print(filename)
-                       except Exception:
-                          # may happen on linux see https://stackoverflow.com/questions/27366479/python-3-os-walk-file-paths-unicodeencodeerror-utf-8-codec-cant-encode-s
-                          pass
+                        try:
+                            print(filename)
+                        except Exception:
+                            # may happen on linux see https://stackoverflow.com/questions/27366479/python-3-os-walk-file-paths-unicodeencodeerror-utf-8-codec-cant-encode-s
+                            pass
                     pdf_files.append(os.sep.join([dirpath, filename]))
 
                     if len(pdf_files) == batch_size_pdf:
-                        self.process_batch(service, pdf_files, input_path, output, n, generateIDs, consolidate_header, consolidate_citations, include_raw_citations, include_raw_affiliations, teiCoordinates, force, verbose)
+                        self.process_batch(
+                            service,
+                            pdf_files,
+                            input_path,
+                            output,
+                            n,
+                            generateIDs,
+                            consolidate_header,
+                            consolidate_citations,
+                            include_raw_citations,
+                            include_raw_affiliations,
+                            teiCoordinates,
+                            force,
+                            verbose,
+                        )
                         pdf_files = []
 
         # last batch
         if len(pdf_files) > 0:
-            self.process_batch(service, pdf_files, input_path, output, n, generateIDs, consolidate_header, consolidate_citations, include_raw_citations, include_raw_affiliations, teiCoordinates, force, verbose)
+            self.process_batch(
+                service,
+                pdf_files,
+                input_path,
+                output,
+                n,
+                generateIDs,
+                consolidate_header,
+                consolidate_citations,
+                include_raw_citations,
+                include_raw_affiliations,
+                teiCoordinates,
+                force,
+                verbose,
+            )
 
-    def process_batch(self, service, pdf_files, input_path, output, n, generateIDs, consolidate_header, consolidate_citations, include_raw_citations, include_raw_affiliations, teiCoordinates, force, verbose=False):
+    def process_batch(
+        self,
+        service,
+        pdf_files,
+        input_path,
+        output,
+        n,
+        generateIDs,
+        consolidate_header,
+        consolidate_citations,
+        include_raw_citations,
+        include_raw_affiliations,
+        teiCoordinates,
+        force,
+        verbose=False,
+    ):
         if verbose:
             print(len(pdf_files), "PDF files to process in current batch")
-        #with concurrent.futures.ThreadPoolExecutor(max_workers=n) as executor:
+        # with concurrent.futures.ThreadPoolExecutor(max_workers=n) as executor:
         with concurrent.futures.ProcessPoolExecutor(max_workers=n) as executor:
             for pdf_file in pdf_files:
-                executor.submit(self.process_pdf, service, pdf_file, input_path, output, generateIDs, consolidate_header, consolidate_citations, include_raw_citations, include_raw_affiliations, teiCoordinates, force, verbose)
+                executor.submit(
+                    self.process_pdf,
+                    service,
+                    pdf_file,
+                    input_path,
+                    output,
+                    generateIDs,
+                    consolidate_header,
+                    consolidate_citations,
+                    include_raw_citations,
+                    include_raw_affiliations,
+                    teiCoordinates,
+                    force,
+                    verbose,
+                )
 
-    def process_pdf(self, service, pdf_file, input_path, output, generateIDs, consolidate_header, consolidate_citations, include_raw_citations, include_raw_affiliations, teiCoordinates, force, verbose=False):
-        # check if TEI file is already produced 
+    def process_pdf(
+        self,
+        service,
+        pdf_file,
+        input_path,
+        output,
+        generateIDs,
+        consolidate_header,
+        consolidate_citations,
+        include_raw_citations,
+        include_raw_affiliations,
+        teiCoordinates,
+        force,
+        verbose=False,
+    ):
+        # check if TEI file is already produced
         # we use ntpath here to be sure it will work on Windows too
         if output is not None:
             pdf_file_name = str(os.path.relpath(os.path.abspath(pdf_file), input_path))
-            filename = os.path.join(output, os.path.splitext(pdf_file_name)[0] + '.tei.xml')
+            filename = os.path.join(
+                output, os.path.splitext(pdf_file_name)[0] + ".tei.xml"
+            )
         else:
             pdf_file_name = ntpath.basename(pdf_file)
-            filename = os.path.join(ntpath.dirname(pdf_file), os.path.splitext(pdf_file_name)[0] + '.tei.xml')
+            filename = os.path.join(
+                ntpath.dirname(pdf_file),
+                os.path.splitext(pdf_file_name)[0] + ".tei.xml",
+            )
 
         if not force and os.path.isfile(filename):
-            print(filename, "already exist, skipping... (use --force to reprocess pdf input files)")
+            print(
+                filename,
+                "already exist, skipping... (use --force to reprocess pdf input files)",
+            )
             return
 
         files = {
-            'input': (
+            "input": (
                 pdf_file,
-                open(pdf_file, 'rb'),
-                'application/pdf',
-                {'Expires': '0'}
+                open(pdf_file, "rb"),
+                "application/pdf",
+                {"Expires": "0"},
             )
         }
-        
-        the_url = 'http://'+self.config['grobid_server']
-        if len(self.config['grobid_port'])>0:
-            the_url += ":"+self.config['grobid_port']
-        the_url += "/api/"+service
+
+        the_url = "http://" + self.config["grobid_server"]
+        if len(self.config["grobid_port"]) > 0:
+            the_url += ":" + self.config["grobid_port"]
+        the_url += "/api/" + service
 
         # set the GROBID parameters
         the_data = {}
         if generateIDs:
-            the_data['generateIDs'] = '1'
+            the_data["generateIDs"] = "1"
         if consolidate_header:
-            the_data['consolidateHeader'] = '1'
+            the_data["consolidateHeader"] = "1"
         if consolidate_citations:
-            the_data['consolidateCitations'] = '1'   
+            the_data["consolidateCitations"] = "1"
         if include_raw_citations:
-            the_data['includeRawCitations'] = '1'
+            the_data["includeRawCitations"] = "1"
         if include_raw_affiliations:
-            the_data['includeRawAffiliations'] = '1'
+            the_data["includeRawAffiliations"] = "1"
         if teiCoordinates:
-            the_data['teiCoordinates'] = self.config['coordinates'] 
+            the_data["teiCoordinates"] = self.config["coordinates"]
 
         res, status = self.post(
-            url=the_url,
-            files=files,
-            data=the_data,
-            headers={'Accept': 'text/plain'}
+            url=the_url, files=files, data=the_data, headers={"Accept": "text/plain"}
         )
 
         if status == 503:
-            time.sleep(self.config['sleep_time'])
-            return self.process_pdf(pdf_file, input_path, output, service, generateIDs, consolidate_header, consolidate_citations, include_raw_citations, include_raw_affiliations, force, teiCoordinates)
+            time.sleep(self.config["sleep_time"])
+            return self.process_pdf(
+                pdf_file,
+                input_path,
+                output,
+                service,
+                generateIDs,
+                consolidate_header,
+                consolidate_citations,
+                include_raw_citations,
+                include_raw_affiliations,
+                force,
+                teiCoordinates,
+            )
         elif status != 200:
-            print('Processing failed with error ' + str(status))
+            print("Processing failed with error " + str(status))
         else:
             # writing TEI file
             try:
-                pathlib.Path(os.path.dirname(filename)).mkdir(parents=True, exist_ok=True)
-                with io.open(filename,'w',encoding='utf8') as tei_file:
+                pathlib.Path(os.path.dirname(filename)).mkdir(
+                    parents=True, exist_ok=True
+                )
+                with io.open(filename, "w", encoding="utf8") as tei_file:
                     tei_file.write(res.text)
-            except OSError:  
-               print ("Writing resulting TEI XML file %s failed" % filename)
-               pass
- 
-if __name__ == "__main__":
-    valid_services = ["processFulltextDocument", "processHeaderDocument", "processReferences"]
+            except OSError:
+                print("Writing resulting TEI XML file %s failed" % filename)
+                pass
 
-    parser = argparse.ArgumentParser(description = "Client for GROBID services")
-    parser.add_argument("service", help="one of [processFulltextDocument, processHeaderDocument, processReferences]")
-    parser.add_argument("--input", default=None, help="path to the directory containing PDF to process") 
-    parser.add_argument("--output", default=None, help="path to the directory where to put the results (optional)") 
-    parser.add_argument("--config", default="./config.json", help="path to the config file, default is ./config.json") 
-    parser.add_argument("--n", default=10, help="concurrency for service usage") 
-    parser.add_argument("--generateIDs", action='store_true', help="generate random xml:id to textual XML elements of the result files") 
-    parser.add_argument("--consolidate_header", action='store_true', help="call GROBID with consolidation of the metadata extracted from the header") 
-    parser.add_argument("--consolidate_citations", action='store_true', help="call GROBID with consolidation of the extracted bibliographical references") 
-    parser.add_argument("--include_raw_citations", action='store_true', help="call GROBID requesting the extraction of raw citations") 
-    parser.add_argument("--include_raw_affiliations", action='store_true', help="call GROBID requestiong the extraciton of raw affiliations") 
-    parser.add_argument("--force", action='store_true', help="force re-processing pdf input files when tei output files already exist")
-    parser.add_argument("--teiCoordinates", action='store_true', help="add the original PDF coordinates (bounding boxes) to the extracted elements")
-    parser.add_argument("--verbose", action='store_true', help="print information about processed files in the console")
+
+if __name__ == "__main__":
+    valid_services = [
+        "processFulltextDocument",
+        "processHeaderDocument",
+        "processReferences",
+    ]
+
+    parser = argparse.ArgumentParser(description="Client for GROBID services")
+    parser.add_argument(
+        "service",
+        help="one of [processFulltextDocument, processHeaderDocument, processReferences]",
+    )
+    parser.add_argument(
+        "--input", default=None, help="path to the directory containing PDF to process"
+    )
+    parser.add_argument(
+        "--output",
+        default=None,
+        help="path to the directory where to put the results (optional)",
+    )
+    parser.add_argument(
+        "--config",
+        default="./config.json",
+        help="path to the config file, default is ./config.json",
+    )
+    parser.add_argument("--n", default=10, help="concurrency for service usage")
+    parser.add_argument(
+        "--generateIDs",
+        action="store_true",
+        help="generate random xml:id to textual XML elements of the result files",
+    )
+    parser.add_argument(
+        "--consolidate_header",
+        action="store_true",
+        help="call GROBID with consolidation of the metadata extracted from the header",
+    )
+    parser.add_argument(
+        "--consolidate_citations",
+        action="store_true",
+        help="call GROBID with consolidation of the extracted bibliographical references",
+    )
+    parser.add_argument(
+        "--include_raw_citations",
+        action="store_true",
+        help="call GROBID requesting the extraction of raw citations",
+    )
+    parser.add_argument(
+        "--include_raw_affiliations",
+        action="store_true",
+        help="call GROBID requestiong the extraciton of raw affiliations",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="force re-processing pdf input files when tei output files already exist",
+    )
+    parser.add_argument(
+        "--teiCoordinates",
+        action="store_true",
+        help="add the original PDF coordinates (bounding boxes) to the extracted elements",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="print information about processed files in the console",
+    )
 
     args = parser.parse_args()
 
     input_path = args.input
     config_path = args.config
     output_path = args.output
-    
+
     if args.n is not None:
         try:
             n = int(args.n)
         except ValueError:
-            print("Invalid concurrency parameter n:", n, "n = 10 will be used by default")
+            print(
+                "Invalid concurrency parameter n:", n, "n = 10 will be used by default"
+            )
             pass
 
     # if output path does not exist, we create it
     if output_path is not None and not os.path.isdir(output_path):
-        try:  
+        try:
             print("output directory does not exist but will be created:", output_path)
             os.makedirs(output_path)
-        except OSError:  
-            print ("Creation of the directory %s failed" % output_path)
-        else:  
-            print ("Successfully created the directory %s" % output_path)
+        except OSError:
+            print("Creation of the directory %s failed" % output_path)
+        else:
+            print("Successfully created the directory %s" % output_path)
 
     service = args.service
     generateIDs = args.generateIDs
@@ -214,17 +363,20 @@ if __name__ == "__main__":
 
     start_time = time.time()
 
-    client.process(service, input_path, 
-            output=output_path, 
-            n=n, 
-            generateIDs=generateIDs, 
-            consolidate_header=consolidate_header, 
-            consolidate_citations=consolidate_citations, 
-            include_raw_citations=include_raw_citations, 
-            include_raw_affiliations=include_raw_affiliations, 
-            teiCoordinates=teiCoordinates,
-            force=force,
-            verbose=verbose)
+    client.process(
+        service,
+        input_path,
+        output=output_path,
+        n=n,
+        generateIDs=generateIDs,
+        consolidate_header=consolidate_header,
+        consolidate_citations=consolidate_citations,
+        include_raw_citations=include_raw_citations,
+        include_raw_affiliations=include_raw_affiliations,
+        teiCoordinates=teiCoordinates,
+        force=force,
+        verbose=verbose,
+    )
 
     runtime = round(time.time() - start_time, 3)
     print("runtime: %s seconds " % (runtime))


### PR DESCRIPTION
Hi there. Thanks for your code!

I took the liberty of running `black` (https://pypi.org/project/black/) to reformat the code according to standards (e.g., PEP-8).
(808e3b2f6c6b817c7950ec4e657f3f2af60c31f4, 60ad3f3289cffd5f741c0993712549ec2381f291).

Secondly (the main reason of my PR), I refactored the code so that `process_pdf()` outputs text instead of writing directly into a TEI file. (557176318b1d5e2f41258210f617a62e62ae68c0)

My use case is: I want to process local files, and then postprocess the resulting TEX xml output directly from Python. For this use case, writing a `.tei.xml` file and then reading it back would incur in a useless overhead.

My changes shouldn't be disruptive: `process_batch()` calls `process_pdf()` as before, with fewer arguments, and it takes care of writing onto a file.

Ideally, in the future it'd be nice if the API exposed `process_batch()` in a similar fashion. But having `process_pdf()` would already be a good thing.

Let me know what you think about these changes.