### PR TITLE
Add a timeout at client requests

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -20,8 +20,6 @@ cd grobid_client_python
 python setup.py install
 ```
 
-
-
 There is nothing more to do to start using the python command lines, see the next section. 
 
 ## Usage and options

--- a/config.json
+++ b/config.json
@@ -3,5 +3,6 @@
     "grobid_port": "8070",
     "batch_size": 1000,
     "sleep_time": 5,
+    "timeout": 60,
     "coordinates": [ "persName", "figure", "ref", "biblStruct", "formula" ]
 }


### PR DESCRIPTION
Add a timeout at the client requests call, default is 60s. 
This avoids blocking a batch too long when a document takes ages to be processed by Grobid.
Note that this timeout does not stops the server task, it just stops waiting for a response from the server.  