### PR TITLE
Option to directly pass the PDF as bytes to process_pdf instead of reading from disk

### DIFF
--- a/grobid_client/grobid_client.py
+++ b/grobid_client/grobid_client.py
@@ -243,9 +243,18 @@ class GrobidClient(ApiClient):
         include_raw_citations,
         include_raw_affiliations,
         tei_coordinates,
-        segment_sentences
+        segment_sentences,
+        from_memory=False
     ):
-        pdf_handle = open(pdf_file, "rb")
+        if from_memory:
+            # PDF already loaded into memory
+            # expects pdf_file to be of type 'bytes'
+            pdf_handle = io.BytesIO(pdf_file)            
+            pdf_file = ""
+        else:
+            # expects pdf_file to be path to PDF file
+            pdf_handle = open(pdf_file, "rb")
+            
         files = {
             "input": (
                 pdf_file,


### PR DESCRIPTION
Hi, it would be nice to be able to pass a PDF file that is already loaded in memory directly to Grobid. In my use case, users upload PDFs using an API, which are then parsed directly without writing the content to files first. The parsing result is then added to a database. As process_pdf already returns the parsing result without writing it to a file, adding the option to pass a PDF as bytes to process_pdf would allow for a workflow where everything is kept in-memory.

Thank you for your great work!