### PR TITLE
add start and end page when calling grobid

### DIFF
--- a/grobid_client/grobid_client.py
+++ b/grobid_client/grobid_client.py
@@ -253,7 +253,9 @@ class GrobidClient(ApiClient):
         include_raw_citations,
         include_raw_affiliations,
         tei_coordinates,
-        segment_sentences
+        segment_sentences,
+        start=-1,
+        end=-1
     ):
         pdf_handle = open(pdf_file, "rb")
         files = {
@@ -283,6 +285,10 @@ class GrobidClient(ApiClient):
             the_data["teiCoordinates"] = self.config["coordinates"]
         if segment_sentences:
             the_data["segmentSentences"] = "1"
+        if start > 0:
+            the_data["start"] = str(start)
+        if end > 0:
+            the_data["end"] = str(end)
 
         try:
             res, status = self.post(

--- a/grobid_client/grobid_client.py
+++ b/grobid_client/grobid_client.py
@@ -306,7 +306,9 @@ class GrobidClient(ApiClient):
                     include_raw_citations,
                     include_raw_affiliations,
                     tei_coordinates,
-                    segment_sentences
+                    segment_sentences,
+                    start,
+                    end
                 )
         except requests.exceptions.ReadTimeout:
             pdf_handle.close()


### PR DESCRIPTION
This PR adds a start and end page in the method when calling grobid.  

The parameters were introduced only in the processing method because it does not make much sense as command line parameter. 