### PR TITLE
Add Dependabot config for GitHub Actions maintenance

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  # Keep GitHub Actions used in the workflows up to date
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "ci"


### PR DESCRIPTION
Automatically monitor the actions used in the CI workflows and open weekly update PRs when newer versions are released.